### PR TITLE
Update ejs to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1447,9 +1447,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
     },
     "emoji-regex": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "body-parser": "^1.18.3",
     "bootstrap": "^3.3.2",
     "compression": "^1.7.3",
-    "ejs": "^2.5.6",
+    "ejs": "^2.6.1",
     "express": "^4.16.3",
     "express-session": "^1.15.6",
     "express-validator": "^5.0.3",


### PR DESCRIPTION
- Test ejs's async API
- The server give me the error log that contains below: 
(node:106301) [DEP0013] DeprecationWarning: Calling an asynchronous 
function without callback is deprecated.