### PR TITLE
Issue Fix : Back button issue in the admin page

### DIFF
--- a/routes/accessDB.js
+++ b/routes/accessDB.js
@@ -233,6 +233,13 @@ module.exports = function(pool) {
   ], (req, res) => {
     const now = moment().format("YYYY.MM.DD HH:mm:ss");
     const err = validationResult(req);
+
+    if (!req.session.userid) {
+      return res.status(403).json({
+        "error": "Forbidden"
+      });
+    }
+
     if (!err.isEmpty()) {
       return res.status(400).json({
         "error": "Bad Request"
@@ -261,7 +268,7 @@ module.exports = function(pool) {
           "error": "Internal Server Error"
         });
       } else {
-        console.log("Delete At " + tableName[len - 1] + "(Id : " + selectId[len - 1] + ") ---Time : " + now);
+        console.log("By " + req.session.userid + ", data is deleted : " + now + ", " + tableName[len - 1] + "(Id : " + selectId[len - 1] + ")");
         res.status(200).send("올바르게 삭제되었습니다.");
       }
     });

--- a/server.js
+++ b/server.js
@@ -91,7 +91,7 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   cookie: {
-    maxAge: 8 * 60 * 60 * 1000 // 8 hours
+    maxAge: 60 * 60 * 1000 // 1 hour
   }
 }));
 


### PR DESCRIPTION
- Issue detail :
  - User can access the admin page after logout from it.
  - To access, the user just click a back button in browser.
  - Reason :
    - Browser cache is enabled in default.
    - So even if the user logout from the admin page, it is accessible.
  - Solution :
    - Disable the cache in the admin page.
    - Redefine the redirect routes to get the admin page.
    - Add the user check logic into /deleteData & /changeMaxLabel.
    - Change cookie maxAge to 1hour from 8hours.